### PR TITLE
Update Irbis TW39 in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ for copyright information.
 | Insignia      | Flex 11                         | yes     | [firmware/insignia/flex11](firmware/insignia/flex11)           |
 | iLife         | ZedBook 2                       | yes     | [firmware/ilife/zedbook2](firmware/ilife/zedbook2)             |
 | IRBIS         | tw48                            | yes     | [firmware/irbis/tw48/](firmware/irbis/tw48)                    |
-| IRBIS         | TW39                            | no      | [firmware/irbis/TW39](firmware/irbis/TW39)                     |
+| IRBIS         | TW39                            | yes (doesn't work)     | [firmware/irbis/TW39](firmware/irbis/TW39)                     |
 | Myria         | MY8307                          | yes     | [firmware/myria/my8307](firmware/myria/my8307)                 |
 | Schneider     | SCT101CTM                       | yes     | [firmware/schneider/sct101ctm](firmware/schneider/sct101ctm)   |
 | techBite      | Arc 11.6                        | yes     | [firmware/techbite/arc_11_6](firmware/techbite/arc_11_6)       |


### PR DESCRIPTION
I tested it on Irbis TW43(Same display and touchscreen), and it doesn't work. Tried both original that I patched myself and the one from the repo. Driver just refuses to load fw. If I just XOR fw it works but then touchscreen isn't calibrated properly