### PR TITLE
update touchscreen_dmi.c example

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,6 @@ static const struct property_entry mycompany_mytablet_props[] = {
 	PROPERTY_ENTRY_U32("touchscreen-size-x", 128),
 	PROPERTY_ENTRY_U32("touchscreen-size-y", 128),
 	PROPERTY_ENTRY_STRING("firmware-name", "gsl1680-mycompany_mytablet.fw"),
-	PROPERTY_ENTRY_U32("silead,max-fingers", 10),
 	{ }
 };
 


### PR DESCRIPTION
noticed during the patch, this is default these days so doesnt need to be there.